### PR TITLE
Updated polymerapp template for latest packages

### DIFF
--- a/templates/polymerapp/lib/main_app.dart
+++ b/templates/polymerapp/lib/main_app.dart
@@ -2,18 +2,19 @@
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
 import 'package:polymer/polymer.dart';
+import 'dart:html';
+import 'package:paper_elements/paper_input.dart';
 
 /// A Polymer `<main-app>` element.
 @CustomTag('main-app')
 class MainApp extends PolymerElement {
-  @observable String input = '';
   @observable String reversed = '';
 
   /// Constructor used to create instance of MainApp.
   MainApp.created() : super.created();
 
-  void inputChanged(String oldValue, String newValue) {
-    reversed = input.split('').reversed.join('');
+  void reverseText(Event event, Object object, PaperInput target) {
+    reversed = target.value.split('').reversed.join('');
   }
 
   // Optional lifecycle methods - uncomment if needed.

--- a/templates/polymerapp/lib/main_app.html
+++ b/templates/polymerapp/lib/main_app.html
@@ -16,7 +16,7 @@
       }
     </style>
 
-    <paper-input label="Type something..." inputValue="{{input}}"></paper-input>
+    <paper-input label="Type something..." on-keyup="{{reverseText}}"></paper-input>
 
     <p>
       Reversed: {{ reversed }}

--- a/templates/polymerapp/pubspec.yaml
+++ b/templates/polymerapp/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: '>=1.0.0 <2.0.0'
 dependencies:
   browser: any
-  polymer: '>=0.15.0 <0.16.0'
-  paper_elements: '>=0.5.0 <0.6.0'
+  polymer: '>=0.15.5 <0.16.0'
+  paper_elements: '>=0.6.1 <0.6.5'
 transformers:
 - polymer:
     entry_points: web/index.html


### PR DESCRIPTION
Updated polymerapp template for polymer 0.15.5 and paper_elements 0.6.1. The template now uses key-up event because valueChanged was not working with the latest paper_elements package. 

PS: Updated lib/generators/polymerapp_data.dart is not built. 