### PR TITLE
First implementation of third party templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ With Dart 1.6:
 
     $> pub global run stagehand
 
+### How to install a third party template
+
+You can use the option git to install a third party template from a git repository:
+
+    $> stagehand --git <git repo url>
+
+Once installed, the generator will be listed while running the stagehand command.
+
+### How to build a third party template
+
+Clone the [emptyStagehandTemplate](https://github.com/kunaldeo/emptyStagehandTemplate) and add your project to template-dir folder. Detailed instructions are available in the README file.
+You can also checkout [polymerContacts](https://github.com/kunaldeo/polymerContacts), it is a complete build of a third party stagehand template.
+
 ## Goals
 
 * Opinionated and prescriptive; minimal to no options

--- a/lib/src/build_generator.dart
+++ b/lib/src/build_generator.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+/**
+ * Return a generator from plugin. This will read pluginData map to extract the information required to build the generator.
+ */
+library stagehand.build_generator;
+
+import 'package:stagehand/src/common.dart';
+import 'package:stagehand/stagehand.dart';
+class PluginGenerator extends DefaultGenerator {
+  String help = "";
+  PluginGenerator(var name, Map pluginData) : super(
+      name,
+      pluginData['info'],
+      pluginData['description'],
+      //TODO: Read this from pluginData
+      categories: const ['dart', 'web']) {
+    for (TemplateFile file in decodeConcanenatedData(pluginData['data'])) {
+      addTemplateFile(file);
+    }
+    setEntrypoint(getFile(pluginData['entrypoint']));
+    help = pluginData['help'];
+  }
+
+  String getInstallInstructions() =>
+  "${super.getInstallInstructions()}\n"
+  + help;
+}

--- a/lib/src/cli_app.dart
+++ b/lib/src/cli_app.dart
@@ -152,7 +152,7 @@ class CliApp {
         return new Future.error(new ArgError('Template already installed.'));
       }
 
-      logger.stdout("Clonning " + repoName);
+      logger.stdout("Cloning " + repoName);
       io.Process.runSync('git', ['clone', options.rest[0], templateLocation]);
       logger.stdout("Running pub in the template directory");
       io.Process.runSync('pub', ['get'], workingDirectory:templateLocation);

--- a/lib/src/cli_app.dart
+++ b/lib/src/cli_app.dart
@@ -122,6 +122,45 @@ class CliApp {
       return analytics.waitForLastPing(timeout: _timeout);
     }
 
+    if (options['git']) {
+      if(options.rest.length == 0) {
+        logger.stderr("No URL specified.\n");
+        _usage(argParser);
+        return new Future.error(new ArgError('no URL specified'));
+      }
+
+      Map<String, String> envVars = io.Platform.environment;
+      String homeDir = envVars['HOME'];
+      String stagehandDataDir = path.join(homeDir, 'stagehandData'); //For storing third party templates
+      
+      String repoUrl = options.rest[0];
+
+      //Get the repo name from URL
+      String expression = r'^((http[s]?|ftp):\/)?\/?([^:\/\s]+)((\/\w+)*\/)([\w\-\.]+[^#?\s]+)(.*)?(#[\w\-]+)?$';
+      RegExp regExp = new RegExp(expression);
+      var matches = regExp.allMatches(repoUrl);
+      var match = matches.elementAt(0);
+      var repoName = match.group(6).replaceFirst(".git", "") //remove trailing git if required
+                     .replaceAll("-", ""); //remove dashes from git repo name if required
+
+      String templateLocation = path.join(stagehandDataDir, repoName);
+
+      if(io.FileSystemEntity.isDirectorySync(templateLocation)) {
+        logger.stderr("Template already installed. If you want to update the template use the update command\n");
+        _usage(argParser);
+        //TODO: Implement template update command
+        return new Future.error(new ArgError('Template already installed.'));
+      }
+
+      logger.stdout("Clonning " + repoName);
+      io.Process.runSync('git', ['clone', options.rest[0], templateLocation]);
+      logger.stdout("Running pub in the template directory");
+      io.Process.runSync('pub', ['get'], workingDirectory:templateLocation);
+      logger.stdout(repoName+ " template Installed !");
+
+      return analytics.waitForLastPing(timeout: _timeout);
+    }
+
     if (options.rest.isEmpty) {
       logger.stderr("No generator specified.\n");
       _usage(argParser);
@@ -140,6 +179,7 @@ class CliApp {
     if (generator == null) {
       logger.stderr("'${generatorName}' is not a valid generator.\n");
       _usage(argParser);
+      //TODO: Search for third party generators installed locally.
       return new Future.error(new ArgError('invalid generator'));
     }
 
@@ -213,6 +253,9 @@ class CliApp {
 
     // Output the list of available projects as json to stdout.
     argParser.addFlag('machine', negatable: false, hide: true);
+
+    // Allows the download of a generator from git
+    argParser.addFlag('git', negatable: false, hide: true);
 
     // Mock out analytics - for use on our testing bots.
     argParser.addFlag('mock-analytics', negatable: false, hide: true);

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -8,6 +8,7 @@
 library stagehand.utils;
 
 import 'dart:convert' show UTF8;
+import 'dart:io' as io;
 
 import 'package:crypto/crypto.dart';
 
@@ -114,6 +115,20 @@ List<String> wrap(String str, [int col = 80]) {
   }
 
   return lines;
+}
+
+/**
+ * Counts no of folders in a given folder
+ */
+int noOfDirectories(io.Directory dir) {
+  int noOfDirs = 0;
+  List<io.FileSystemEntity> dirList = dir.listSync(recursive: false, followLinks: false);
+  for (io.FileSystemEntity f in dirList) {
+    if (io.FileSystemEntity.isDirectorySync(f.path)) {
+      noOfDirs += 1;
+    }
+  }
+  return noOfDirs;
 }
 
 /**

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   http: '>=0.11.0 <0.12.0'
   path: '>=1.3.0 <2.0.0'
   usage: '>=0.0.6 <0.1.0'
+  plugins: '1.0.3'
 
 dev_dependencies:
   browser: any


### PR DESCRIPTION
Here is the complete working implementation of third-party template system for stagehand.
To install a third party package:
```stagehand --git <Git Repo URL>```
You can use this example third party template at  https://github.com/kunaldeo/stagehandtrialtemp. Template has the following structure:
```
├── main.dart
├── pubspec.yaml
└── src
    └── stagehandtrialtemp_data.dart
```
This pull request merges all the commits in PR https://github.com/google/stagehand/pull/202 . Please see it for earlier discussions.