### PR TITLE
Update gitignore templates

### DIFF
--- a/templates/console-full/.gitignore
+++ b/templates/console-full/.gitignore
@@ -7,11 +7,17 @@ build/
 **/packages/
 
 # Files created by dart2js
-*.js
-*.precompiled.js
+*.dart.js
+*.part.js
 *.js.deps
 *.js.map
 *.info.json
 
 # Directory created by dartdoc
-doc/
+doc/api/
+
+# JetBrains IDEs (WebStorm and IDEA are the recomended Dart IDEs) 
+.idea/
+*.iml
+*.ipr
+*.iws

--- a/templates/console-full/.gitignore
+++ b/templates/console-full/.gitignore
@@ -2,8 +2,8 @@
 .buildlog
 .packages
 .project
-.pub
-build
+.pub/
+build/
 packages
 pubspec.lock # (Remove this pattern if you wish to check in your lock file)
 

--- a/templates/console-full/.gitignore
+++ b/templates/console-full/.gitignore
@@ -2,9 +2,10 @@
 .buildlog
 .packages
 .project
-.pub/
-build/
-**/packages/
+.pub
+build
+packages
+pubspec.lock # (Remove this pattern if you wish to check in your lock file)
 
 # Files created by dart2js
 *.dart.js

--- a/templates/console-full/.gitignore
+++ b/templates/console-full/.gitignore
@@ -1,8 +1,17 @@
+# Files and directories created by pub
 .buildlog
-.DS_Store
-.idea
 .packages
+.project
 .pub/
 build/
-packages
-pubspec.lock
+**/packages/
+
+# Files created by dart2js
+*.js
+*.precompiled.js
+*.js.deps
+*.js.map
+*.info.json
+
+# Directory created by dartdoc
+doc/

--- a/templates/package-simple/.gitignore
+++ b/templates/package-simple/.gitignore
@@ -7,14 +7,20 @@ build/
 **/packages/
 
 # Files created by dart2js
-*.js
-*.precompiled.js
+*.dart.js
+*.part.js
 *.js.deps
 *.js.map
 *.info.json
 
 # Directory created by dartdoc
-doc/
+doc/api/
 
-# This is a library package
+# This is a library package, so ignore pub lock file
 pubspec.lock
+
+# JetBrains IDEs (WebStorm and IDEA are the recomended Dart IDEs) 
+.idea/
+*.iml
+*.ipr
+*.iws

--- a/templates/package-simple/.gitignore
+++ b/templates/package-simple/.gitignore
@@ -1,8 +1,20 @@
+# Files and directories created by pub
 .buildlog
-.DS_Store
-.idea
 .packages
+.project
 .pub/
 build/
-packages
+**/packages/
+
+# Files created by dart2js
+*.js
+*.precompiled.js
+*.js.deps
+*.js.map
+*.info.json
+
+# Directory created by dartdoc
+doc/
+
+# This is a library package
 pubspec.lock

--- a/templates/package-simple/.gitignore
+++ b/templates/package-simple/.gitignore
@@ -2,9 +2,10 @@
 .buildlog
 .packages
 .project
-.pub/
-build/
-**/packages/
+.pub
+build
+packages
+pubspec.lock
 
 # Files created by dart2js
 *.dart.js
@@ -15,9 +16,6 @@ build/
 
 # Directory created by dartdoc
 doc/api/
-
-# This is a library package, so ignore pub lock file
-pubspec.lock
 
 # JetBrains IDEs (WebStorm and IDEA are the recomended Dart IDEs) 
 .idea/

--- a/templates/package-simple/.gitignore
+++ b/templates/package-simple/.gitignore
@@ -2,8 +2,8 @@
 .buildlog
 .packages
 .project
-.pub
-build
+.pub/
+build/
 packages
 pubspec.lock
 

--- a/templates/server-appengine/.gitignore
+++ b/templates/server-appengine/.gitignore
@@ -7,11 +7,17 @@ build/
 **/packages/
 
 # Files created by dart2js
-*.js
-*.precompiled.js
+*.dart.js
+*.part.js
 *.js.deps
 *.js.map
 *.info.json
 
 # Directory created by dartdoc
-doc/
+doc/api/
+
+# JetBrains IDEs (WebStorm and IDEA are the recomended Dart IDEs) 
+.idea/
+*.iml
+*.ipr
+*.iws

--- a/templates/server-appengine/.gitignore
+++ b/templates/server-appengine/.gitignore
@@ -2,8 +2,8 @@
 .buildlog
 .packages
 .project
-.pub
-build
+.pub/
+build/
 packages
 pubspec.lock # (Remove this pattern if you wish to check in your lock file)
 

--- a/templates/server-appengine/.gitignore
+++ b/templates/server-appengine/.gitignore
@@ -2,9 +2,10 @@
 .buildlog
 .packages
 .project
-.pub/
-build/
-**/packages/
+.pub
+build
+packages
+pubspec.lock # (Remove this pattern if you wish to check in your lock file)
 
 # Files created by dart2js
 *.dart.js

--- a/templates/server-appengine/.gitignore
+++ b/templates/server-appengine/.gitignore
@@ -1,4 +1,17 @@
+# Files and directories created by pub
+.buildlog
 .packages
+.project
 .pub/
-packages
-pubspec.lock
+build/
+**/packages/
+
+# Files created by dart2js
+*.js
+*.precompiled.js
+*.js.deps
+*.js.map
+*.info.json
+
+# Directory created by dartdoc
+doc/

--- a/templates/server-shelf/.gitignore
+++ b/templates/server-shelf/.gitignore
@@ -7,11 +7,17 @@ build/
 **/packages/
 
 # Files created by dart2js
-*.js
-*.precompiled.js
+*.dart.js
+*.part.js
 *.js.deps
 *.js.map
 *.info.json
 
 # Directory created by dartdoc
-doc/
+doc/api/
+
+# JetBrains IDEs (WebStorm and IDEA are the recomended Dart IDEs) 
+.idea/
+*.iml
+*.ipr
+*.iws

--- a/templates/server-shelf/.gitignore
+++ b/templates/server-shelf/.gitignore
@@ -2,8 +2,8 @@
 .buildlog
 .packages
 .project
-.pub
-build
+.pub/
+build/
 packages
 pubspec.lock # (Remove this pattern if you wish to check in your lock file)
 

--- a/templates/server-shelf/.gitignore
+++ b/templates/server-shelf/.gitignore
@@ -2,9 +2,10 @@
 .buildlog
 .packages
 .project
-.pub/
-build/
-**/packages/
+.pub
+build
+packages
+pubspec.lock # (Remove this pattern if you wish to check in your lock file)
 
 # Files created by dart2js
 *.dart.js

--- a/templates/server-shelf/.gitignore
+++ b/templates/server-shelf/.gitignore
@@ -1,8 +1,17 @@
+# Files and directories created by pub
 .buildlog
-.DS_Store
-.idea
 .packages
+.project
 .pub/
 build/
-packages
-pubspec.lock
+**/packages/
+
+# Files created by dart2js
+*.js
+*.precompiled.js
+*.js.deps
+*.js.map
+*.info.json
+
+# Directory created by dartdoc
+doc/

--- a/templates/web-polymer/.gitignore
+++ b/templates/web-polymer/.gitignore
@@ -7,11 +7,17 @@ build/
 **/packages/
 
 # Files created by dart2js
-*.js
-*.precompiled.js
+*.dart.js
+*.part.js
 *.js.deps
 *.js.map
 *.info.json
 
 # Directory created by dartdoc
-doc/
+doc/api/
+
+# JetBrains IDEs (WebStorm and IDEA are the recomended Dart IDEs) 
+.idea/
+*.iml
+*.ipr
+*.iws

--- a/templates/web-polymer/.gitignore
+++ b/templates/web-polymer/.gitignore
@@ -2,8 +2,8 @@
 .buildlog
 .packages
 .project
-.pub
-build
+.pub/
+build/
 packages
 pubspec.lock # (Remove this pattern if you wish to check in your lock file)
 

--- a/templates/web-polymer/.gitignore
+++ b/templates/web-polymer/.gitignore
@@ -2,9 +2,10 @@
 .buildlog
 .packages
 .project
-.pub/
-build/
-**/packages/
+.pub
+build
+packages
+pubspec.lock # (Remove this pattern if you wish to check in your lock file)
 
 # Files created by dart2js
 *.dart.js

--- a/templates/web-polymer/.gitignore
+++ b/templates/web-polymer/.gitignore
@@ -1,8 +1,17 @@
+# Files and directories created by pub
 .buildlog
-.DS_Store
-.idea
 .packages
+.project
 .pub/
 build/
-packages
-pubspec.lock
+**/packages/
+
+# Files created by dart2js
+*.js
+*.precompiled.js
+*.js.deps
+*.js.map
+*.info.json
+
+# Directory created by dartdoc
+doc/

--- a/templates/web-simple/.gitignore
+++ b/templates/web-simple/.gitignore
@@ -7,11 +7,17 @@ build/
 **/packages/
 
 # Files created by dart2js
-*.js
-*.precompiled.js
+*.dart.js
+*.part.js
 *.js.deps
 *.js.map
 *.info.json
 
 # Directory created by dartdoc
-doc/
+doc/api/
+
+# JetBrains IDEs (WebStorm and IDEA are the recomended Dart IDEs) 
+.idea/
+*.iml
+*.ipr
+*.iws

--- a/templates/web-simple/.gitignore
+++ b/templates/web-simple/.gitignore
@@ -2,8 +2,8 @@
 .buildlog
 .packages
 .project
-.pub
-build
+.pub/
+build/
 packages
 pubspec.lock # (Remove this pattern if you wish to check in your lock file)
 

--- a/templates/web-simple/.gitignore
+++ b/templates/web-simple/.gitignore
@@ -2,9 +2,10 @@
 .buildlog
 .packages
 .project
-.pub/
-build/
-**/packages/
+.pub
+build
+packages
+pubspec.lock # (Remove this pattern if you wish to check in your lock file)
 
 # Files created by dart2js
 *.dart.js

--- a/templates/web-simple/.gitignore
+++ b/templates/web-simple/.gitignore
@@ -1,8 +1,17 @@
+# Files and directories created by pub
 .buildlog
-.DS_Store
-.idea
 .packages
+.project
 .pub/
 build/
-packages
-pubspec.lock
+**/packages/
+
+# Files created by dart2js
+*.js
+*.precompiled.js
+*.js.deps
+*.js.map
+*.info.json
+
+# Directory created by dartdoc
+doc/


### PR DESCRIPTION
1. Include pattern for `pubspec.lock` in package-simple library package
only
1. Remove pattern for IntelliJ specific `.idea`
1. Remove pattern for MacOS specific `.DS_Store`
1. Update patterns for files and directories generated by *pub*
1. Add patterns for files generated by *dart2js*
1. Add pattern for directory created by *dartdoc*

Patterns for *pub*, *dart2js* and*dartdoc* are designed to work with Dart SDK 1.12, and are in sync with Dart .gitignore at https://github.com/github/gitignore.

Sources:

* https://www.dartlang.org/tools/private-files.html
* https://stackoverflow.com/questions/20314796/which-files-are-generated-when-executing-dart2js-and-why
* https://www.dartlang.org/tools/dart2js/



