### PR TITLE
Update reflectable entry point format

### DIFF
--- a/templates/web-polymer/pubspec.yaml
+++ b/templates/web-polymer/pubspec.yaml
@@ -18,7 +18,7 @@ transformers:
 - web_components:
     entry_points: web/index.html
 - reflectable:
-    entry_points: web/index.dart
+    entry_points: web/index.bootstrap.initialize.dart
 - $dart2js:
     $include: '**/*.bootstrap.initialize.dart'
     minify: true


### PR DESCRIPTION
If people use html imports containing dart scripts then the reflectable transformer needs to run on the bootstrap file, otherwise it can't reach the entire program.