### PR TITLE
rev to 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # CHANGELOG
 
+## 0.2.6
+- Updated the Polymer and Angular templates to the latest packages
+
 ## 0.2.5+4
-- Added a reference to the webcomponents-lite.js in the polymer template
+- Added a reference to the webcomponents-lite.js in the Polymer template
 
 ## 0.2.5+3
 

--- a/lib/src/cli_app.dart
+++ b/lib/src/cli_app.dart
@@ -19,7 +19,7 @@ import 'package:usage/usage_io.dart';
 const String APP_NAME = 'stagehand';
 
 // This version must be updated in tandem with the pubspec version.
-const String APP_VERSION = '0.2.5+4';
+const String APP_VERSION = '0.2.6';
 
 const String APP_PUB_INFO =
     'https://pub.dartlang.org/packages/${APP_NAME}.json';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: stagehand
 # When changing this version, change the lib/src/cli_app.dart version as well.
-version: 0.2.5+4
+version: 0.2.6
 description: >
   A scaffolding generator for your Dart projects. Stagehand helps you get set
   up!


### PR DESCRIPTION
Rev to `0.2.6` to capture the latest updates to the angular and polymer templates.

https://github.com/google/stagehand/pull/299
https://github.com/google/stagehand/pull/298