### PR TITLE
Fix example on stagehand.pub

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -79,7 +79,7 @@ $ pub global activate stagehand
       <pre><code>
 $ mkdir fancy_project
 $ cd fancy_project
-$ stagehand webapp
+$ stagehand web-simple
       </code></pre>
 
       <p>Stagehand contains a highly curated list of templates:</p>


### PR DESCRIPTION
`stagehand webapp` results in an error on my system. Changed to `stagehand web-simple`, which works.