### PR TITLE
Changed shelf listener address

### DIFF
--- a/templates/server-shelf/bin/server.dart
+++ b/templates/server-shelf/bin/server.dart
@@ -22,7 +22,7 @@ void main(List<String> args) {
       .addMiddleware(shelf.logRequests())
       .addHandler(_echoRequest);
 
-  io.serve(handler, 'localhost', port).then((server) {
+  io.serve(handler, '0.0.0.0', port).then((server) {
     print('Serving at http://${server.address.host}:${server.port}');
   });
 }


### PR DESCRIPTION
Hi,

In order to make it easier to deploy simple test apps created with stagehand I suggest that the listener address is changed so that it works both on localhost and on any hosted platform, standalone VMs or PaaS alternatives. As a reference the [app engine example](https://github.com/dart-lang/appengine/blob/master/lib/src/server/server.dart#L30) already uses '0.0.0.0' instead of localhost.