### PR TITLE
Add commented out .analysis_options file to all templates

### DIFF
--- a/lib/generators/console_full_data.dart
+++ b/lib/generators/console_full_data.dart
@@ -3,6 +3,16 @@
 // license that can be found in the LICENSE file.
 
 const List<String> data = const [
+  ".analysis_options",
+  "text",
+  """IyBUaGlzIGZpbGUgYWxsb3dzIHlvdSB0byBjb25maWd1cmUgdGhlIERhcnQgYW5hbHl6ZXIuCiMK
+IyBUaGUgY29tbWVudGVkIHBhcnQgYmVsb3cgaXMganVzdCBmb3IgaW5zcGlyYXRpb24uIFJlYWQg
+dGhlIGd1aWRlIGhlcmU6CiMgaHR0cHM6Ly9naXRodWIuY29tL2RhcnQtbGFuZy9zZGsvdHJlZS9t
+YXN0ZXIvcGtnL2FuYWx5emVyI2NvbmZpZ3VyaW5nLXRoZS1hbmFseXplcgoKIyBhbmFseXplcjoK
+IyAgIHN0cm9uZy1tb2RlOiB0cnVlCiMgICBleGNsdWRlczoKIyAgICAgLSBwYXRoL3RvL2V4Y2x1
+ZGVkL2ZpbGVzLyoqCiMgbGludGVyOgojICAgcnVsZXM6CiMgICAgICMgc2VlIGNhdGFsb2d1ZSBo
+ZXJlOiBodHRwOi8vZGFydC1sYW5nLmdpdGh1Yi5pby9saW50ZXIvbGludHMvCiMgICAgIC0gaGFz
+aF9hbmRfZXF1YWxz""",
   ".gitignore",
   "text",
   """IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLnBhY2thZ2VzCi5wdWIvCmJ1

--- a/lib/generators/console_simple_data.dart
+++ b/lib/generators/console_simple_data.dart
@@ -3,6 +3,16 @@
 // license that can be found in the LICENSE file.
 
 const List<String> data = const [
+  ".analysis_options",
+  "text",
+  """IyBUaGlzIGZpbGUgYWxsb3dzIHlvdSB0byBjb25maWd1cmUgdGhlIERhcnQgYW5hbHl6ZXIuCiMK
+IyBUaGUgY29tbWVudGVkIHBhcnQgYmVsb3cgaXMganVzdCBmb3IgaW5zcGlyYXRpb24uIFJlYWQg
+dGhlIGd1aWRlIGhlcmU6CiMgaHR0cHM6Ly9naXRodWIuY29tL2RhcnQtbGFuZy9zZGsvdHJlZS9t
+YXN0ZXIvcGtnL2FuYWx5emVyI2NvbmZpZ3VyaW5nLXRoZS1hbmFseXplcgoKIyBhbmFseXplcjoK
+IyAgIHN0cm9uZy1tb2RlOiB0cnVlCiMgICBleGNsdWRlczoKIyAgICAgLSBwYXRoL3RvL2V4Y2x1
+ZGVkL2ZpbGVzLyoqCiMgbGludGVyOgojICAgcnVsZXM6CiMgICAgICMgc2VlIGNhdGFsb2d1ZSBo
+ZXJlOiBodHRwOi8vZGFydC1sYW5nLmdpdGh1Yi5pby9saW50ZXIvbGludHMvCiMgICAgIC0gaGFz
+aF9hbmRfZXF1YWxz""",
   ".gitignore",
   "text",
   """IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLnBhY2thZ2VzCi5wdWIvCnBh

--- a/lib/generators/package_simple_data.dart
+++ b/lib/generators/package_simple_data.dart
@@ -3,6 +3,16 @@
 // license that can be found in the LICENSE file.
 
 const List<String> data = const [
+  ".analysis_options",
+  "text",
+  """IyBUaGlzIGZpbGUgYWxsb3dzIHlvdSB0byBjb25maWd1cmUgdGhlIERhcnQgYW5hbHl6ZXIuCiMK
+IyBUaGUgY29tbWVudGVkIHBhcnQgYmVsb3cgaXMganVzdCBmb3IgaW5zcGlyYXRpb24uIFJlYWQg
+dGhlIGd1aWRlIGhlcmU6CiMgaHR0cHM6Ly9naXRodWIuY29tL2RhcnQtbGFuZy9zZGsvdHJlZS9t
+YXN0ZXIvcGtnL2FuYWx5emVyI2NvbmZpZ3VyaW5nLXRoZS1hbmFseXplcgoKIyBhbmFseXplcjoK
+IyAgIHN0cm9uZy1tb2RlOiB0cnVlCiMgICBleGNsdWRlczoKIyAgICAgLSBwYXRoL3RvL2V4Y2x1
+ZGVkL2ZpbGVzLyoqCiMgbGludGVyOgojICAgcnVsZXM6CiMgICAgICMgc2VlIGNhdGFsb2d1ZSBo
+ZXJlOiBodHRwOi8vZGFydC1sYW5nLmdpdGh1Yi5pby9saW50ZXIvbGludHMvCiMgICAgIC0gaGFz
+aF9hbmRfZXF1YWxz""",
   ".gitignore",
   "text",
   """IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLnBhY2thZ2VzCi5wdWIvCmJ1

--- a/lib/generators/server_appengine_data.dart
+++ b/lib/generators/server_appengine_data.dart
@@ -3,6 +3,16 @@
 // license that can be found in the LICENSE file.
 
 const List<String> data = const [
+  ".analysis_options",
+  "text",
+  """IyBUaGlzIGZpbGUgYWxsb3dzIHlvdSB0byBjb25maWd1cmUgdGhlIERhcnQgYW5hbHl6ZXIuCiMK
+IyBUaGUgY29tbWVudGVkIHBhcnQgYmVsb3cgaXMganVzdCBmb3IgaW5zcGlyYXRpb24uIFJlYWQg
+dGhlIGd1aWRlIGhlcmU6CiMgaHR0cHM6Ly9naXRodWIuY29tL2RhcnQtbGFuZy9zZGsvdHJlZS9t
+YXN0ZXIvcGtnL2FuYWx5emVyI2NvbmZpZ3VyaW5nLXRoZS1hbmFseXplcgoKIyBhbmFseXplcjoK
+IyAgIHN0cm9uZy1tb2RlOiB0cnVlCiMgICBleGNsdWRlczoKIyAgICAgLSBwYXRoL3RvL2V4Y2x1
+ZGVkL2ZpbGVzLyoqCiMgbGludGVyOgojICAgcnVsZXM6CiMgICAgICMgc2VlIGNhdGFsb2d1ZSBo
+ZXJlOiBodHRwOi8vZGFydC1sYW5nLmdpdGh1Yi5pby9saW50ZXIvbGludHMvCiMgICAgIC0gaGFz
+aF9hbmRfZXF1YWxz""",
   ".gitignore",
   "text",
   """IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLnBhY2thZ2VzCi5wdWIvCmJ1

--- a/lib/generators/server_shelf_data.dart
+++ b/lib/generators/server_shelf_data.dart
@@ -3,6 +3,16 @@
 // license that can be found in the LICENSE file.
 
 const List<String> data = const [
+  ".analysis_options",
+  "text",
+  """IyBUaGlzIGZpbGUgYWxsb3dzIHlvdSB0byBjb25maWd1cmUgdGhlIERhcnQgYW5hbHl6ZXIuCiMK
+IyBUaGUgY29tbWVudGVkIHBhcnQgYmVsb3cgaXMganVzdCBmb3IgaW5zcGlyYXRpb24uIFJlYWQg
+dGhlIGd1aWRlIGhlcmU6CiMgaHR0cHM6Ly9naXRodWIuY29tL2RhcnQtbGFuZy9zZGsvdHJlZS9t
+YXN0ZXIvcGtnL2FuYWx5emVyI2NvbmZpZ3VyaW5nLXRoZS1hbmFseXplcgoKIyBhbmFseXplcjoK
+IyAgIHN0cm9uZy1tb2RlOiB0cnVlCiMgICBleGNsdWRlczoKIyAgICAgLSBwYXRoL3RvL2V4Y2x1
+ZGVkL2ZpbGVzLyoqCiMgbGludGVyOgojICAgcnVsZXM6CiMgICAgICMgc2VlIGNhdGFsb2d1ZSBo
+ZXJlOiBodHRwOi8vZGFydC1sYW5nLmdpdGh1Yi5pby9saW50ZXIvbGludHMvCiMgICAgIC0gaGFz
+aF9hbmRfZXF1YWxz""",
   ".gitignore",
   "text",
   """IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLnBhY2thZ2VzCi5wdWIvCmJ1

--- a/lib/generators/web_angular_data.dart
+++ b/lib/generators/web_angular_data.dart
@@ -3,6 +3,16 @@
 // license that can be found in the LICENSE file.
 
 const List<String> data = const [
+  ".analysis_options",
+  "text",
+  """IyBUaGlzIGZpbGUgYWxsb3dzIHlvdSB0byBjb25maWd1cmUgdGhlIERhcnQgYW5hbHl6ZXIuCiMK
+IyBUaGUgY29tbWVudGVkIHBhcnQgYmVsb3cgaXMganVzdCBmb3IgaW5zcGlyYXRpb24uIFJlYWQg
+dGhlIGd1aWRlIGhlcmU6CiMgaHR0cHM6Ly9naXRodWIuY29tL2RhcnQtbGFuZy9zZGsvdHJlZS9t
+YXN0ZXIvcGtnL2FuYWx5emVyI2NvbmZpZ3VyaW5nLXRoZS1hbmFseXplcgoKIyBhbmFseXplcjoK
+IyAgIHN0cm9uZy1tb2RlOiB0cnVlCiMgICBleGNsdWRlczoKIyAgICAgLSBwYXRoL3RvL2V4Y2x1
+ZGVkL2ZpbGVzLyoqCiMgbGludGVyOgojICAgcnVsZXM6CiMgICAgICMgc2VlIGNhdGFsb2d1ZSBo
+ZXJlOiBodHRwOi8vZGFydC1sYW5nLmdpdGh1Yi5pby9saW50ZXIvbGludHMvCiMgICAgIC0gaGFz
+aF9hbmRfZXF1YWxz""",
   ".gitignore",
   "text",
   """IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLnBhY2thZ2VzCi5wdWIvCmJ1

--- a/lib/generators/web_angular_data.dart
+++ b/lib/generators/web_angular_data.dart
@@ -21,14 +21,18 @@ dG8gY2hlY2sgaW4geW91ciBsb2NrIGZpbGUKcHVic3BlYy5sb2NrCgojIEZpbGVzIGNyZWF0ZWQg
 YnkgZGFydDJqcwoqLmRhcnQuanMKKi5wYXJ0LmpzCiouanMuZGVwcwoqLmpzLm1hcAoqLmluZm8u
 anNvbgoKIyBEaXJlY3RvcnkgY3JlYXRlZCBieSBkYXJ0ZG9jCmRvYy9hcGkvCgojIEpldEJyYWlu
 cyBJREVzCi5pZGVhLwoqLmltbAoqLmlwcgoqLml3cwo=""",
+  "lib/app_component.css",
+  "text",
+  """Omhvc3QgewogICAgZm9udC1mYW1pbHk6IFJvYm90bywgSGVsdmV0aWNhLCBBcmlhbCwgc2Fucy1z
+ZXJpZjsKfQ==""",
   "lib/app_component.dart",
   "text",
   """Ly8gQ29weXJpZ2h0IChjKSBfX3llYXJfXywgX19hdXRob3JfXy4gQWxsIHJpZ2h0cyByZXNlcnZl
 ZC4gVXNlIG9mIHRoaXMgc291cmNlIGNvZGUKLy8gaXMgZ292ZXJuZWQgYnkgYSBCU0Qtc3R5bGUg
 bGljZW5zZSB0aGF0IGNhbiBiZSBmb3VuZCBpbiB0aGUgTElDRU5TRSBmaWxlLgoKaW1wb3J0ICdw
-YWNrYWdlOmFuZ3VsYXIyL2NvcmUuZGFydCc7CgpAQ29tcG9uZW50KHNlbGVjdG9yOiAnbXktYXBw
-JywgdGVtcGxhdGVVcmw6ICdhcHBfY29tcG9uZW50Lmh0bWwnKQpjbGFzcyBBcHBDb21wb25lbnQg
-e30K""",
+YWNrYWdlOmFuZ3VsYXIyL2NvcmUuZGFydCc7CgpAQ29tcG9uZW50KAogICAgc2VsZWN0b3I6ICdt
+eS1hcHAnLAogICAgc3R5bGVVcmxzOiBjb25zdCBbJ2FwcF9jb21wb25lbnQuY3NzJ10sCiAgICB0
+ZW1wbGF0ZVVybDogJ2FwcF9jb21wb25lbnQuaHRtbCcpCmNsYXNzIEFwcENvbXBvbmVudCB7fQo=""",
   "lib/app_component.html",
   "text",
   "PGgxPk15IEZpcnN0IEFuZ3VsYXIgMiBBcHA8L2gxPgo=",

--- a/lib/generators/web_polymer_data.dart
+++ b/lib/generators/web_polymer_data.dart
@@ -3,6 +3,16 @@
 // license that can be found in the LICENSE file.
 
 const List<String> data = const [
+  ".analysis_options",
+  "text",
+  """IyBUaGlzIGZpbGUgYWxsb3dzIHlvdSB0byBjb25maWd1cmUgdGhlIERhcnQgYW5hbHl6ZXIuCiMK
+IyBUaGUgY29tbWVudGVkIHBhcnQgYmVsb3cgaXMganVzdCBmb3IgaW5zcGlyYXRpb24uIFJlYWQg
+dGhlIGd1aWRlIGhlcmU6CiMgaHR0cHM6Ly9naXRodWIuY29tL2RhcnQtbGFuZy9zZGsvdHJlZS9t
+YXN0ZXIvcGtnL2FuYWx5emVyI2NvbmZpZ3VyaW5nLXRoZS1hbmFseXplcgoKIyBhbmFseXplcjoK
+IyAgIHN0cm9uZy1tb2RlOiB0cnVlCiMgICBleGNsdWRlczoKIyAgICAgLSBwYXRoL3RvL2V4Y2x1
+ZGVkL2ZpbGVzLyoqCiMgbGludGVyOgojICAgcnVsZXM6CiMgICAgICMgc2VlIGNhdGFsb2d1ZSBo
+ZXJlOiBodHRwOi8vZGFydC1sYW5nLmdpdGh1Yi5pby9saW50ZXIvbGludHMvCiMgICAgIC0gaGFz
+aF9hbmRfZXF1YWxz""",
   ".gitignore",
   "text",
   """IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLnBhY2thZ2VzCi5wdWIvCmJ1

--- a/lib/generators/web_simple_data.dart
+++ b/lib/generators/web_simple_data.dart
@@ -3,6 +3,16 @@
 // license that can be found in the LICENSE file.
 
 const List<String> data = const [
+  ".analysis_options",
+  "text",
+  """IyBUaGlzIGZpbGUgYWxsb3dzIHlvdSB0byBjb25maWd1cmUgdGhlIERhcnQgYW5hbHl6ZXIuCiMK
+IyBUaGUgY29tbWVudGVkIHBhcnQgYmVsb3cgaXMganVzdCBmb3IgaW5zcGlyYXRpb24uIFJlYWQg
+dGhlIGd1aWRlIGhlcmU6CiMgaHR0cHM6Ly9naXRodWIuY29tL2RhcnQtbGFuZy9zZGsvdHJlZS9t
+YXN0ZXIvcGtnL2FuYWx5emVyI2NvbmZpZ3VyaW5nLXRoZS1hbmFseXplcgoKIyBhbmFseXplcjoK
+IyAgIHN0cm9uZy1tb2RlOiB0cnVlCiMgICBleGNsdWRlczoKIyAgICAgLSBwYXRoL3RvL2V4Y2x1
+ZGVkL2ZpbGVzLyoqCiMgbGludGVyOgojICAgcnVsZXM6CiMgICAgICMgc2VlIGNhdGFsb2d1ZSBo
+ZXJlOiBodHRwOi8vZGFydC1sYW5nLmdpdGh1Yi5pby9saW50ZXIvbGludHMvCiMgICAgIC0gaGFz
+aF9hbmRfZXF1YWxz""",
   ".gitignore",
   "text",
   """IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLnBhY2thZ2VzCi5wdWIvCmJ1

--- a/templates/console-full/.analysis_options
+++ b/templates/console-full/.analysis_options
@@ -1,0 +1,13 @@
+# This file allows you to configure the Dart analyzer.
+#
+# The commented part below is just for inspiration. Read the guide here:
+# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
+
+# analyzer:
+#   strong-mode: true
+#   excludes:
+#     - path/to/excluded/files/**
+# linter:
+#   rules:
+#     # see catalogue here: http://dart-lang.github.io/linter/lints/
+#     - hash_and_equals

--- a/templates/console-simple/.analysis_options
+++ b/templates/console-simple/.analysis_options
@@ -1,0 +1,13 @@
+# This file allows you to configure the Dart analyzer.
+#
+# The commented part below is just for inspiration. Read the guide here:
+# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
+
+# analyzer:
+#   strong-mode: true
+#   excludes:
+#     - path/to/excluded/files/**
+# linter:
+#   rules:
+#     # see catalogue here: http://dart-lang.github.io/linter/lints/
+#     - hash_and_equals

--- a/templates/package-simple/.analysis_options
+++ b/templates/package-simple/.analysis_options
@@ -1,0 +1,13 @@
+# This file allows you to configure the Dart analyzer.
+#
+# The commented part below is just for inspiration. Read the guide here:
+# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
+
+# analyzer:
+#   strong-mode: true
+#   excludes:
+#     - path/to/excluded/files/**
+# linter:
+#   rules:
+#     # see catalogue here: http://dart-lang.github.io/linter/lints/
+#     - hash_and_equals

--- a/templates/server-appengine/.analysis_options
+++ b/templates/server-appengine/.analysis_options
@@ -1,0 +1,13 @@
+# This file allows you to configure the Dart analyzer.
+#
+# The commented part below is just for inspiration. Read the guide here:
+# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
+
+# analyzer:
+#   strong-mode: true
+#   excludes:
+#     - path/to/excluded/files/**
+# linter:
+#   rules:
+#     # see catalogue here: http://dart-lang.github.io/linter/lints/
+#     - hash_and_equals

--- a/templates/server-shelf/.analysis_options
+++ b/templates/server-shelf/.analysis_options
@@ -1,0 +1,13 @@
+# This file allows you to configure the Dart analyzer.
+#
+# The commented part below is just for inspiration. Read the guide here:
+# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
+
+# analyzer:
+#   strong-mode: true
+#   excludes:
+#     - path/to/excluded/files/**
+# linter:
+#   rules:
+#     # see catalogue here: http://dart-lang.github.io/linter/lints/
+#     - hash_and_equals

--- a/templates/web-angular/.analysis_options
+++ b/templates/web-angular/.analysis_options
@@ -1,0 +1,13 @@
+# This file allows you to configure the Dart analyzer.
+#
+# The commented part below is just for inspiration. Read the guide here:
+# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
+
+# analyzer:
+#   strong-mode: true
+#   excludes:
+#     - path/to/excluded/files/**
+# linter:
+#   rules:
+#     # see catalogue here: http://dart-lang.github.io/linter/lints/
+#     - hash_and_equals

--- a/templates/web-angular/lib/app_component.css
+++ b/templates/web-angular/lib/app_component.css
@@ -1,0 +1,3 @@
+:host {
+    font-family: Roboto, Helvetica, Arial, sans-serif;
+}

--- a/templates/web-angular/lib/app_component.dart
+++ b/templates/web-angular/lib/app_component.dart
@@ -3,5 +3,8 @@
 
 import 'package:angular2/core.dart';
 
-@Component(selector: 'my-app', templateUrl: 'app_component.html')
+@Component(
+    selector: 'my-app',
+    styleUrls: const ['app_component.css'],
+    templateUrl: 'app_component.html')
 class AppComponent {}

--- a/templates/web-polymer/.analysis_options
+++ b/templates/web-polymer/.analysis_options
@@ -1,0 +1,13 @@
+# This file allows you to configure the Dart analyzer.
+#
+# The commented part below is just for inspiration. Read the guide here:
+# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
+
+# analyzer:
+#   strong-mode: true
+#   excludes:
+#     - path/to/excluded/files/**
+# linter:
+#   rules:
+#     # see catalogue here: http://dart-lang.github.io/linter/lints/
+#     - hash_and_equals

--- a/templates/web-simple/.analysis_options
+++ b/templates/web-simple/.analysis_options
@@ -1,0 +1,13 @@
+# This file allows you to configure the Dart analyzer.
+#
+# The commented part below is just for inspiration. Read the guide here:
+# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
+
+# analyzer:
+#   strong-mode: true
+#   excludes:
+#     - path/to/excluded/files/**
+# linter:
+#   rules:
+#     # see catalogue here: http://dart-lang.github.io/linter/lints/
+#     - hash_and_equals

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -11,6 +11,11 @@ import 'package:grinder/grinder.dart';
 import 'package:path/path.dart' as path;
 import 'package:stagehand/stagehand.dart' as stagehand;
 
+const List<String> _allowedDotFiles = const <String>[
+  ".gitignore",
+  ".analysis_options"
+];
+
 final RegExp _binaryFileTypes = new RegExp(
     r'\.(jpe?g|png|gif|ico|svg|ttf|eot|woff|woff2)$',
     caseSensitive: false);
@@ -89,7 +94,7 @@ Iterable<String> _traverse(Directory dir, String root) sync* {
 
     String name = path.basename(entity.path);
     if (name == 'pubspec.lock') continue;
-    if (name.startsWith('.') && name != '.gitignore') continue;
+    if (name.startsWith('.') && !_allowedDotFiles.contains(name)) continue;
 
     if (entity is Directory) {
       yield* _traverse(entity, '${root}${name}/');


### PR DESCRIPTION
Discussed in issue https://github.com/google/stagehand/issues/329.

The `.analysis_options` file looks thusly:

```
# This file allows you to configure the Dart analyzer.
#
# The commented part below is just for inspiration. Read the guide here:
# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer

# analyzer:
#   strong-mode: true
#   excludes:
#     - path/to/excluded/files/**
# linter:
#   rules:
#     # see catalogue here: http://dart-lang.github.io/linter/lints/
#     - hash_and_equals
```

I made sure (via `tool/grind.dart test`) than even when you un-comment `strong-mode`, all templates build and analyze without warnings. 

