### PR TITLE
rename templates for consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 .buildlog
 .pub
 .settings/
+*.iml

--- a/lib/generators/console_simple.dart
+++ b/lib/generators/console_simple.dart
@@ -7,11 +7,11 @@ import '../src/common.dart';
 import 'console_simple_data.dart';
 
 /**
- * A generator for a hello world command-line application.
+ * A generator for a simple hello world command-line application.
  */
 class ConsoleSimpleGenerator extends DefaultGenerator {
   ConsoleSimpleGenerator()
-      : super('console-simple', 'Console Application',
+      : super('console-simple', 'Simple Console Application',
             'A simple command-line application.',
             categories: const ['dart', 'console']) {
     for (TemplateFile file in decodeConcatenatedData(data)) {

--- a/lib/generators/web_simple.dart
+++ b/lib/generators/web_simple.dart
@@ -11,7 +11,7 @@ import 'web_simple_data.dart';
  */
 class WebSimpleGenerator extends DefaultGenerator {
   WebSimpleGenerator()
-      : super('web-simple', 'Uber Simple Web Application',
+      : super('web-simple', 'Simple Web Application',
             'An absolute bare-bones web app.',
             categories: const ['dart', 'web']) {
     for (TemplateFile file in decodeConcatenatedData(data)) {


### PR DESCRIPTION
rename some templates for consistency:

- one of the console app templates goes from `Console Application` to `Simple Console Application` (we had two templates with the same name)
- `Uber Simple Web Application` => `Simple Web Application` to match the above

@kwalrath @kevmoo 