### PR TITLE
1.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## unreleased
+## 1.0.14
 - Renamed `Console Application` to `Simple Console Application`
 - Renamed `Uber Simple Web Application` to `Simple Web Application`
 - Removed the `App Engine Application` sample

--- a/lib/src/cli_app.dart
+++ b/lib/src/cli_app.dart
@@ -17,7 +17,7 @@ import 'package:usage/usage_io.dart';
 const String APP_NAME = 'stagehand';
 
 // This version must be updated in tandem with the pubspec version.
-const String APP_VERSION = '1.0.13';
+const String APP_VERSION = '1.0.14';
 
 const String APP_PUB_INFO =
     'https://pub.dartlang.org/packages/${APP_NAME}.json';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: stagehand
 # When changing this version, change the lib/src/cli_app.dart version as well.
-version: 1.0.13
+version: 1.0.14
 description: >
   A scaffolding generator for your Dart projects. Stagehand helps you get set
   up!


### PR DESCRIPTION
rev to `1.0.14`; capture:

- Renamed `Console Application` to `Simple Console Application`
- Renamed `Uber Simple Web Application` to `Simple Web Application`
- Removed the `App Engine Application` sample

@kevmoo @kwalrath 