### PR TITLE
Remove platform_* options from Angular pubspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+
+- Removed `platform_*` options from `web-angular`.
+
 ## 1.1.2
 
 - Removed `web-angular-simple` and `console-simple` templates:

--- a/lib/src/cli_app.dart
+++ b/lib/src/cli_app.dart
@@ -17,7 +17,7 @@ import 'package:usage/usage_io.dart';
 const String APP_NAME = 'stagehand';
 
 // This version must be updated in tandem with the pubspec version.
-const String APP_VERSION = '1.1.2';
+const String APP_VERSION = '1.1.3';
 
 const String APP_PUB_INFO =
     'https://pub.dartlang.org/packages/${APP_NAME}.json';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ name: stagehand
 description: >
   A scaffolding generator for your Dart projects. Stagehand helps you get set
   up!
-version: 1.1.2
+version: 1.1.3
 homepage: http://stagehand.pub
 authors:
 - Seth Ladd <sethladd@google.com>

--- a/templates/web-angular/lib/app_component.dart
+++ b/templates/web-angular/lib/app_component.dart
@@ -1,7 +1,7 @@
 // Copyright (c) __year__, __author__. All rights reserved. Use of this source code
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/core.dart';
+import 'package:angular2/angular2.dart';
 import 'package:angular_components/angular_components.dart';
 
 import 'todo_list/todo_list_component.dart';

--- a/templates/web-angular/lib/todo_list/todo_list_component.dart
+++ b/templates/web-angular/lib/todo_list/todo_list_component.dart
@@ -3,7 +3,7 @@
 
 import 'dart:async';
 
-import 'package:angular2/core.dart';
+import 'package:angular2/angular2.dart';
 import 'package:angular_components/angular_components.dart';
 
 import 'todo_list_service.dart';
@@ -12,7 +12,10 @@ import 'todo_list_service.dart';
   selector: 'todo-list',
   styleUrls: const ['todo_list_component.css'],
   templateUrl: 'todo_list_component.html',
-  directives: const [materialDirectives],
+  directives: const [
+    CORE_DIRECTIVES,
+    materialDirectives,
+  ],
   providers: const [TodoListService],
 )
 class TodoListComponent implements OnInit {

--- a/templates/web-angular/pubspec.yaml
+++ b/templates/web-angular/pubspec.yaml
@@ -19,10 +19,6 @@ dev_dependencies:
 
 transformers:
 - angular2:
-    platform_directives:
-    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
-    platform_pipes:
-    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - angular2/transform/reflection_remover:
     $include: test/**_test.dart


### PR DESCRIPTION
As per https://github.com/dart-lang/angular2/issues/363, this is deprecated.

Closes https://github.com/google/stagehand/issues/410.