### PR TITLE
rename 'Shelf Web Server' to 'Web Server'

### DIFF
--- a/lib/generators/server_shelf.dart
+++ b/lib/generators/server_shelf.dart
@@ -7,11 +7,11 @@ import '../src/common.dart';
 import 'server_shelf_data.dart';
 
 /**
- * A generator for a hello world command-line application.
+ * A generator for a server app built on `package:shelf`.
  */
 class ServerShelfGenerator extends DefaultGenerator {
   ServerShelfGenerator()
-      : super('server-shelf', 'Shelf Web Server',
+      : super('server-shelf', 'Web Server',
             'A web server built using the shelf package.',
             categories: const ['dart', 'shelf', 'server']) {
     for (TemplateFile file in decodeConcatenatedData(data)) {


### PR DESCRIPTION
Rename the `Shelf Web Server` app to `Web Server`. It's the only server app in the template list now, and we're not really trying to promote shelf (we still mention shelf in the template description).